### PR TITLE
Bump Hadoop to 3.1.3 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV HADOOP_VERSION=$version \
     USER=hdfs
 
 
-RUN apt-get update && apt-get install -y curl procps && rm -rf /var/lib/apt/lists/* && \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl procps && rm -rf /var/lib/apt/lists/* && \
     curl -SL https://archive.apache.org/dist/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz | tar xvz -C /opt && \
     ln -s /opt/hadoop-$HADOOP_VERSION /opt/hadoop && \
     # remove documentation from container image

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,15 @@ ENV HADOOP_VERSION=$version \
     HDFS_CONF_dfs_datanode_data_dir=file:///dfs/data \
     USER=hdfs
 
-
-RUN apt-get update && apt-get upgrade -y && apt-get install -y curl procps && rm -rf /var/lib/apt/lists/* && \
-    curl -SL https://archive.apache.org/dist/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz | tar xvz -C /opt && \
-    ln -s /opt/hadoop-$HADOOP_VERSION /opt/hadoop && \
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y curl procps && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -SL "https://archive.apache.org/dist/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz" | tar xvz -C /opt && \
+    ln -s "/opt/hadoop-$HADOOP_VERSION" /opt/hadoop && \
     # remove documentation from container image
     rm -r /opt/hadoop/share/doc && \
-    if [ ! -f $HADOOP_CONF_DIR/mapred-site.xml ]; then \
-    cp $HADOOP_CONF_DIR/mapred-site.xml.template $HADOOP_CONF_DIR/mapred-site.xml; \
+    if [ ! -f "$HADOOP_CONF_DIR/mapred-site.xml" ]; then \
+        cp "$HADOOP_CONF_DIR/mapred-site.xml.template" "$HADOOP_CONF_DIR/mapred-site.xml"; \
     fi && \
     groupadd -g 114 -r hadoop && \
     useradd --comment "Hadoop HDFS" -u 201 --shell /bin/bash -M -r --groups hadoop --home /var/lib/hadoop/hdfs hdfs && \
@@ -30,7 +31,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y curl procps && rm
     mkdir -p /opt/hadoop/logs && \
     chown -R hdfs:hadoop /dfs && \
     chown -LR hdfs:hadoop /opt/hadoop
-   
+
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8-jre-slim
 LABEL maintainer="cgiraldo@gradiant.org" \
       organization="gradiant.org"
 
-ARG version=2.7.7
+ARG version=3.1.3
 ENV HADOOP_VERSION=$version \
     HADOOP_PREFIX=/opt/hadoop \
     HADOOP_HOME=/opt/hadoop \

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Image also accepts configuration through simple environment variable that transl
 We provide two docker-compose files to deploy a 3-datanode and a single-datanode hdfs clusters.
 
 ```
-HADOOP_VERSION=2.7.7 docker-compose -f tests/docker-compose.yml  up -d
+HADOOP_VERSION=3.1.3 docker-compose -f tests/docker-compose.yml  up -d
 ```
 Then, Hdfs UI is available at:
 - [http://localhost:50070](http://localhost:50070) for hadoop 2.x
@@ -68,7 +68,7 @@ Then, Hdfs UI is available at:
 
 To undeploy:
 ```
-HADOOP_VERSION=2.7.7 docker-compose -f tests/docker-compose.yml  down
+HADOOP_VERSION=3.1.3 docker-compose -f tests/docker-compose.yml  down
 ```
 
 ## Testing

--- a/tests/test-hdfs-multiple-datanodes.sh
+++ b/tests/test-hdfs-multiple-datanodes.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-HADOOP_VERSION="${HADOOP_VERSION:-2.7.7}"
+set -x
+HADOOP_VERSION="${HADOOP_VERSION:-3.1.3}"
 
 HADOOP_VERSION=$HADOOP_VERSION docker-compose up -d
 

--- a/tests/test-hdfs-single-datanode.sh
+++ b/tests/test-hdfs-single-datanode.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-HADOOP_VERSION="${HADOOP_VERSION:-2.7.7}"
+set -x
+HADOOP_VERSION="${HADOOP_VERSION:-3.1.3}"
 
 HADOOP_VERSION=$HADOOP_VERSION docker-compose -f docker-compose-single-datanode.yml up -d
 


### PR DESCRIPTION
Hadoop 3.1.x is recoomended to HBase 2.x.y versions
(where x is 1 or higher)
according to https://hbase.apache.org/book.html#hadoop

Not sure about HBase 2.0.z though...

Signed-off-by: Michał Sochoń <kaszpir@gmail.com>